### PR TITLE
Base and arm trajectories are decoupled to avoid spinning

### DIFF
--- a/squirrel_handovers/include/squirrel_handovers/handover.hpp
+++ b/squirrel_handovers/include/squirrel_handovers/handover.hpp
@@ -37,7 +37,8 @@
 #define SAFETY_TOPIC "/reset_safety"
 
 #define TILT_TOPIC "/tilt_controller/command"
-#define PAN_TOPIC "/pan_controller/command"
+#define PAN_TOPIC "/head_controller/command"
+#define PAN_ANGLE 1.0
 
 
 enum Axes

--- a/squirrel_object_manipulation/include/squirrel_object_manipulation/squirrel_object_manipulation_server.h
+++ b/squirrel_object_manipulation/include/squirrel_object_manipulation/squirrel_object_manipulation_server.h
@@ -536,6 +536,12 @@ class SquirrelObjectManipulationServer
 
     void publishGoalMarker ( const geometry_msgs::Pose &pose, int id = 0 );
 
+    /**
+     * \brief Publishes the feedback of the action server with a status
+     * \param[in] status The status of the current phase
+     */
+    void publishFeedback ( const std::string &status );
+
 };
 
 /**

--- a/squirrel_object_manipulation/include/squirrel_object_manipulation/squirrel_object_manipulation_server.h
+++ b/squirrel_object_manipulation/include/squirrel_object_manipulation/squirrel_object_manipulation_server.h
@@ -22,6 +22,7 @@
 #include <squirrel_manipulation_msgs/SoftHandGrasp.h>
 #include <haf_grasping/CalcGraspPointsServerAction.h>
 #include <mongodb_store/message_store.h>
+#include <mongodb_store_msgs/MongoInsertMsg.h>
 #include <squirrel_object_perception_msgs/SceneObject.h>
 #include <squirrel_object_perception_msgs/CreateOctomapWithLumps.h>
 #include <dynamic_reconfigure/server.h>
@@ -37,7 +38,7 @@
 #define JOINT_FRAME_ "odom"
 #define PLANNING_LINK_ "hand_wrist_link"
 #define GRASPING_LINK_ "hand_palm_link"
-#define APPROACH_TOLERANCE_ 0.01
+#define APPROACH_TOLERANCE_ 0.005
 #define MAX_REPLAN_TRY_ 3
 #define NUM_BASE_JOINTS_ 3
 #define NUM_ARM_JOINTS_ 5
@@ -45,11 +46,11 @@
 #define DEFAULT_APPROACH_HEIGHT_ 0.10  // meters
 #define MAX_WAIT_TRAJECTORY_COMPLETION_ 60.0  // seconds
 #define JOINT_IN_POSITION_THRESHOLD_ 0.139626 // 8 degrees
-#define METAHAND_MINIMUM_HEIGHT_ 0.05  //22  // meters
+#define METAHAND_MINIMUM_HEIGHT_ 0.07  //22  // meters
 #define SOFTHAND_MINIMUM_HEIGHT_ 0.17  // meters
 #define FINGER_CLEARANCE_ 0.1  // meters
 #define HAF_MIN_DIST_ 0.75
-#define HAF_SEARCH_SIZE_ 40
+#define HAF_SEARCH_SIZE_ 50
 #define LOCK_BASE_VAL_ -10.0 
 #define LOCK_ARM_VAL_ -20.0
 #define BASE_TO_FINAL_VAL_ -30.0
@@ -69,6 +70,7 @@
 #define STR_GRASP_ "grasp"
 #define STR_PICK_ "pick"
 #define STR_RETRACT_ "retract"
+#define STR_CARRY_ "carry"
 #define STR_PLACE_ "place"
 
 /**

--- a/squirrel_object_manipulation/launch/jb_squirrel_object_manipulation.launch
+++ b/squirrel_object_manipulation/launch/jb_squirrel_object_manipulation.launch
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<launch>
+
+    <!-- Parameters -->
+    <arg name="robot" default="tuw-robotino2"/>
+    <arg name="hand" default="metahand" />
+    <arg name="action_name" default="squirrel_object_manipulation_server" />
+    <arg name="planning_time" default="3.0" />
+    <arg name="plan_with_octomap_collisions" default="true" />
+    <arg name="plan_with_self_collisions" default="true" />
+    <arg name="approach_height" default="0.15" /> <!-- 0.15 -->
+    <arg name="full_placement" default="false" />
+
+    <!-- Action Server -->
+    <node name="squirrel_object_manipulation_server" pkg="squirrel_object_manipulation" type="squirrel_object_manipulation_server" output="screen">
+        <rosparam command="load" file="$(find squirrel_8dof_planner)/config/folding_poses_$(arg robot).yaml" />
+        <param name="action_name" type="string" value="$(arg action_name)"/>
+        <param name="hand" type="string" value="$(arg hand)"/>
+        <param name="planning_time" type="double" value="$(arg planning_time)"/>
+        <param name="plan_with_octomap_collisions" type="bool" value="$(arg plan_with_octomap_collisions)"/>
+        <param name="plan_with_self_collisions" type="bool" value="$(arg plan_with_self_collisions)"/>
+        <param name="approach_height" type="double" value="$(arg approach_height)"/>
+        <param name="full_placement" type="bool" value="$(arg full_placement)"/>
+    </node>
+
+</launch>

--- a/squirrel_object_manipulation/launch/squirrel_object_manipulation.launch
+++ b/squirrel_object_manipulation/launch/squirrel_object_manipulation.launch
@@ -6,8 +6,8 @@
 	<arg name="hand" default="metahand" />
 	<arg name="action_name" default="squirrel_object_manipulation_server" />
 	<arg name="planning_time" default="3.0" />
-    <arg name="plan_with_octomap_collisions" default="true" />
-	<arg name="plan_with_self_collisions" default="true" />
+    <arg name="plan_with_octomap_collisions" default="false" />
+	<arg name="plan_with_self_collisions" default="false" />
     <arg name="approach_height" default="0.15" /> <!-- 0.15 -->
     <arg name="full_placement" default="false" />
 

--- a/squirrel_object_manipulation/launch/squirrel_object_manipulation.launch
+++ b/squirrel_object_manipulation/launch/squirrel_object_manipulation.launch
@@ -9,6 +9,7 @@
     <arg name="plan_with_octomap_collisions" default="true" />
 	<arg name="plan_with_self_collisions" default="true" />
     <arg name="approach_height" default="0.15" /> <!-- 0.15 -->
+    <arg name="full_placement" default="false" />
 
 	<!-- Action Server -->
 	<node name="squirrel_object_manipulation_server" pkg="squirrel_object_manipulation" type="squirrel_object_manipulation_server" output="screen">
@@ -18,7 +19,8 @@
 		<param name="planning_time" type="double" value="$(arg planning_time)"/>
 		<param name="plan_with_octomap_collisions" type="bool" value="$(arg plan_with_octomap_collisions)"/>
 		<param name="plan_with_self_collisions" type="bool" value="$(arg plan_with_self_collisions)"/>
-		<param name="approach_height" type="double" value="$(arg approach_height)"/>
+        <param name="approach_height" type="double" value="$(arg approach_height)"/>
+        <param name="full_placement" type="bool" value="$(arg full_placement)"/>
 	</node>
 
 </launch>

--- a/squirrel_object_manipulation/scripts/tuw_test_manipulation.py
+++ b/squirrel_object_manipulation/scripts/tuw_test_manipulation.py
@@ -18,6 +18,7 @@ if __name__ == '__main__':
 
     manipulation_goal = ManipulationGoal()
     manipulation_goal.manipulation_type = 'haf pick'
+    #manipulation_goal.manipulation_type = 'place'
     manipulation_goal.pose.header.stamp = rospy.Time.now()
     manipulation_goal.pose.header.frame_id = 'map'
     

--- a/squirrel_object_manipulation/scripts/tuw_test_manipulation.py
+++ b/squirrel_object_manipulation/scripts/tuw_test_manipulation.py
@@ -17,15 +17,15 @@ if __name__ == '__main__':
     client.wait_for_server()
 
     manipulation_goal = ManipulationGoal()
-    manipulation_goal.manipulation_type = 'haf pick'
+    manipulation_goal.manipulation_type = 'pick'
     #manipulation_goal.manipulation_type = 'place'
     manipulation_goal.pose.header.stamp = rospy.Time.now()
     manipulation_goal.pose.header.frame_id = 'map'
     
     # Define the pose of the object
     if manipulation_goal.pose.header.frame_id == 'map':
-        manipulation_goal.pose.pose.position.x = 1.96
-        manipulation_goal.pose.pose.position.y = 1.28
+        manipulation_goal.pose.pose.position.x = 2.65 # new yelow cross 3.85 # original orange cross 1.96
+        manipulation_goal.pose.pose.position.y = 1.58 # new yellow cross 1.35 # original orange cross 1.28
         manipulation_goal.pose.pose.position.z = 0.10
     else:
         manipulation_goal.pose.pose.position.x = 0.2

--- a/squirrel_object_manipulation/scripts/tuw_test_manipulation.py
+++ b/squirrel_object_manipulation/scripts/tuw_test_manipulation.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     client.wait_for_server()
 
     manipulation_goal = ManipulationGoal()
-    manipulation_goal.manipulation_type = 'pick'
+    manipulation_goal.manipulation_type = 'haf pick'
     manipulation_goal.pose.header.stamp = rospy.Time.now()
     manipulation_goal.pose.header.frame_id = 'map'
     

--- a/squirrel_object_manipulation/src/squirrel_object_manipulation_server.cpp
+++ b/squirrel_object_manipulation/src/squirrel_object_manipulation_server.cpp
@@ -1501,6 +1501,13 @@ bool SquirrelObjectManipulationServer::sendCommandTrajectory ( const std::string
             arm_msg.points.back().positions[2] = joints[2];
             arm_msg.points.back().time_from_start = time;
         }
+        // Make sure it reaches the last position
+        time += time_between_poses;
+        arm_msg.points.push_back ( latest_trajectory_.points.back() );
+        arm_msg.points.back().positions[0] = joints[0];
+        arm_msg.points.back().positions[1] = joints[1];
+        arm_msg.points.back().positions[2] = joints[2];
+        arm_msg.points.back().time_from_start = time;
         // Send the trajectory to the controller
         ROS_INFO ( "[SquirrelObjectManipulationServer::sendCommandTrajectory] Moving arm" );
         trajectory_controller_pub_.publish ( arm_msg );

--- a/squirrel_object_manipulation/src/squirrel_object_manipulation_server.cpp
+++ b/squirrel_object_manipulation/src/squirrel_object_manipulation_server.cpp
@@ -1463,6 +1463,8 @@ bool SquirrelObjectManipulationServer::sendCommandTrajectory ( const std::string
     // Otherwise, decoupling the base and arm
     else
     {
+        ROS_WARN ( "[SquirrelObjectManipulationServer::sendCommandTrajectory] Decoupling base and arm for action '%s'", message.c_str() );
+
         // -- Send the base command first (send the last base pose of the trajectory)
         trajectory_msgs::JointTrajectory base_msg;
         base_msg.joint_names.resize(8);

--- a/squirrel_object_manipulation/src/squirrel_object_manipulation_server.cpp
+++ b/squirrel_object_manipulation/src/squirrel_object_manipulation_server.cpp
@@ -451,7 +451,7 @@ bool SquirrelObjectManipulationServer::actuateHand ( const HandActuation &hand_a
     else if ( hand_type_ == SquirrelObjectManipulationServer::SOFTHAND ) return actuateSofthand ( hand_actuation);
     else ROS_ERROR ( "[SquirrelObjectManipulationServer::actuateHand] Unrecognized hand type" );
 
-    // If made it here then did not reconize the actuation type
+    // If made it here then did not recognize the actuation type
     return false;
 }
 
@@ -750,7 +750,7 @@ bool SquirrelObjectManipulationServer::grasp ( const squirrel_manipulation_msgs:
     // ***
     // Grasp
     // ***
-    if ( !moveArmCartesian(grasp_goal, STR_GRASP_, APPROACH_TOLERANCE_) )
+    if ( !moveArmCartesian(grasp_goal, STR_GRASP_) )
     {
         ROS_ERROR ( "[SquirrelObjectManipulationServer::grasp] Failed to reach grasp pose" );
         return false;
@@ -866,7 +866,7 @@ bool SquirrelObjectManipulationServer::pick ( const squirrel_manipulation_msgs::
     // Pick
     // ***
     moveHead ( HEAD_TO_HAND_ );
-    if ( !moveArmCartesian(pick_goal, STR_PICK_, APPROACH_TOLERANCE_) )
+    if ( !moveArmCartesian(pick_goal, STR_PICK_) )
     {
         ROS_ERROR ( "[SquirrelObjectManipulationServer::pick] Failed to reach pick up pose" );
         return false;

--- a/squirrel_object_manipulation/src/squirrel_object_manipulation_server.cpp
+++ b/squirrel_object_manipulation/src/squirrel_object_manipulation_server.cpp
@@ -1231,6 +1231,10 @@ bool SquirrelObjectManipulationServer::moveArmCartesian ( const double &x, const
     bool decouple_base_arm = false;
     if ( message.compare(STR_APPROACH_) != 0 )
       decouple_base_arm = checkTrajectoryHasSpin();
+    if ( decouple_base_arm ) ROS_WARN ( "Decouple is TRUE" );
+    else                     ROS_WARN ( "Decouple is FALSE" );
+    std::cout << "Press enter to continue..." << std::endl;
+    std::cin.ignore();
 
     // Send the command to the arm controller
     ROS_INFO ( "[SquirrelObjectManipulationServer::moveArmCartesian] Moving to '%s' pose", message.c_str() );


### PR DESCRIPTION
8dof trajectories between the approach pose and the grasp/retract pose have the base and arm decoupled to avoid spinning behaviour. Decoupling is only allowed between approach and grasp or approach and retract.